### PR TITLE
余分なバージョン表記の削除

### DIFF
--- a/internal/presenter/server.go
+++ b/internal/presenter/server.go
@@ -18,7 +18,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// バージョン管理
 	{
 		versionHandler := version.NewVersionHandler()
-		v1.GET("/v1/version", versionHandler.V1Version)
+		v1.GET("/version", versionHandler.V1Version)
 	}
 
 	err := r.Run()


### PR DESCRIPTION
#7 
version endpointを、
`/v1/v1/version`から、`/v1/version`に変更